### PR TITLE
Add ROOT dependency for `+form` variant

### DIFF
--- a/spack_repo/phlex/packages/phlex/package.py
+++ b/spack_repo/phlex/packages/phlex/package.py
@@ -34,8 +34,7 @@ class Phlex(CMakePackage, FnalGithubPackage):
     depends_on("catch2", type=("build", "test"))
 
     with when("+form"):
-        # Put depends_on() calls specific to FORM here
-        pass
+        depends_on("root +root7")
 
 
     def cmake_args(self):


### PR DESCRIPTION
Unfortunately, there is not a good way to specify `cxxstd` for `root` based on `phlex`'s value for `cxxstd`.