### PR TITLE
Update `PHLEX_PLUGIN_PATH` to include directory with phlex-provided plugins

### DIFF
--- a/spack_repo/phlex/packages/phlex/package.py
+++ b/spack_repo/phlex/packages/phlex/package.py
@@ -43,9 +43,10 @@ class Phlex(CMakePackage, FnalGithubPackage):
 
     @cmake_preset
     def cmake_args(self):
-        define = self.define
-        define_from_variant = self.define_from_variant
         return [
             self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
             self.define_from_variant("PHLEX_USE_FORM", "form")
         ]
+
+    def setup_run_environment(self, env):
+        env.prepend_path("PHLEX_PLUGIN_PATH", self.prefix.lib)


### PR DESCRIPTION
Users of Phlex prototype 0.1 will need to be able to load the `generate_layers`, `form_module`, and `pymodule`.  This PR adjusts the `PHLEX_PLUGIN_PATH` to be able to load these plugins (assuming they are installed in Phlex's `lib` directory).