### PR TITLE
Include `py-packaging` as build dependency

### DIFF
--- a/spack_repo/phlex/packages/phlex/package.py
+++ b/spack_repo/phlex/packages/phlex/package.py
@@ -39,6 +39,7 @@ class Phlex(CMakePackage, FnalGithubPackage):
 
     depends_on("python@3.11:")
     depends_on("py-numpy@2:")
+    depends_on("py-packaging", type="build") # Used to check (e.g.) numpy veresions in CMake
 
     with when("+form"):
         for std in (20, 23):


### PR DESCRIPTION
As long as we're [using `py-packaging`](https://github.com/Framework-R-D/phlex/blob/2d6eaa46b4a6d06cae537c66e158f3e465e20102/plugins/python/CMakeLists.txt#L13) to check version numbers, we should make sure that it's included as a build dependency of `phlex`.  I encountered import errors when not including this dependency.