### PR TITLE
Adjust Python dependency according to CMake

### DIFF
--- a/spack_repo/phlex/packages/phlex/package.py
+++ b/spack_repo/phlex/packages/phlex/package.py
@@ -30,14 +30,14 @@ class Phlex(CMakePackage, FnalGithubPackage):
 
     depends_on("cxx", type="build")
 
-    depends_on("boost@1.75.0: +json+program_options+stacktrace")
+    depends_on("boost@1.75.0: +json+program_options")
     depends_on("fmt@:9")
     depends_on("jsonnet")
     depends_on("spdlog")
     depends_on("tbb")
     depends_on("catch2", type=("build", "test"))
 
-    depends_on("python@3.11:")
+    depends_on("python@3.12:")
     depends_on("py-numpy@2:")
     depends_on("py-packaging", type="build") # Used to check (e.g.) numpy veresions in CMake
 


### PR DESCRIPTION
In Phlex's `CMakeLists.txt` files (e.g., see [here](https://github.com/Framework-R-D/phlex/blob/2d6eaa46b4a6d06cae537c66e158f3e465e20102/plugins/python/CMakeLists.txt#L1)), the minimum Python version is 3.12.  This PR adjusts the recipe to reflect that.

Also, use of Boost's stacktrace library was removed with PR https://github.com/Framework-R-D/phlex/pull/12.  Boost's `stacktrace` Spack variant is thus removed in this PR.