### PR TITLE
Update Boost to 1.88 and fmt to 11.2

### DIFF
--- a/spack_repo/phlex/packages/phlex/package.py
+++ b/spack_repo/phlex/packages/phlex/package.py
@@ -31,7 +31,7 @@ class Phlex(CMakePackage, FnalGithubPackage):
     depends_on("cxx", type="build")
 
     depends_on("boost@1.88.0: +json+program_options")
-    depends_on("fmt@:9")
+    depends_on("fmt@11.2:")
     depends_on("jsonnet")
     depends_on("spdlog")
     depends_on("tbb")

--- a/spack_repo/phlex/packages/phlex/package.py
+++ b/spack_repo/phlex/packages/phlex/package.py
@@ -39,7 +39,7 @@ class Phlex(CMakePackage, FnalGithubPackage):
 
     depends_on("python@3.12:")
     depends_on("py-numpy@2:")
-    depends_on("py-packaging", type="build") # Used to check (e.g.) numpy veresions in CMake
+    depends_on("py-packaging", type="build") # Used to check (e.g.) numpy versions in CMake
 
     with when("+form"):
         for std in (20, 23):

--- a/spack_repo/phlex/packages/phlex/package.py
+++ b/spack_repo/phlex/packages/phlex/package.py
@@ -30,7 +30,7 @@ class Phlex(CMakePackage, FnalGithubPackage):
 
     depends_on("cxx", type="build")
 
-    depends_on("boost@1.75.0: +json+program_options")
+    depends_on("boost@1.88.0: +json+program_options")
     depends_on("fmt@:9")
     depends_on("jsonnet")
     depends_on("spdlog")


### PR DESCRIPTION
- Boost update is to allow use of the hash2 library
- fmt update is to allow use of the format_as feature 