### PR TITLE
Constrain CMake to version 3.31 or newer

### DIFF
--- a/spack_repo/phlex/packages/phlex/package.py
+++ b/spack_repo/phlex/packages/phlex/package.py
@@ -36,6 +36,7 @@ class Phlex(CMakePackage, FnalGithubPackage):
 
     variant("form", default=True, description="Build with experimental FORM integration")
 
+    depends_on("cmake@3.31:", type="build")
     depends_on("cxx", type="build")
 
     depends_on("boost@1.88.0: +json+program_options")


### PR DESCRIPTION
As required by [phlex](https://github.com/Framework-R-D/phlex/blob/ec9333177d27e3194d3802970a28ce719de34a05/CMakeLists.txt#L1).