### PR TITLE
Add pkg-config dependency to check FFI availability

### DIFF
--- a/spack_repo/phlex/packages/phlex/package.py
+++ b/spack_repo/phlex/packages/phlex/package.py
@@ -53,6 +53,7 @@ class Phlex(CMakePackage, FnalGithubPackage):
     depends_on("py-pytest", type="build")
     depends_on("py-pyyaml", type="build")  # Used in scripts testing
     with when("@0.3:"):
+        depends_on("pkg-config", type="build")
         depends_on("py-numba")
         depends_on("libffi")  # Used in combination with numba
 


### PR DESCRIPTION
This dependency is required as of Framework-R-D/phlex#626. See [here](https://github.com/Framework-R-D/phlex/blob/371bd833967daa620722134ee67ff04336299405/plugins/python/CMakeLists.txt#L10,L11).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Build system: added a conditional build-time `pkg-config` dependency for `phlex` versions `@0.3:` in `spack_repo/phlex/packages/phlex/package.py`.
- Dependency management: the new dependency is scoped to the existing `with when("`@0.3`:")` block, so earlier versions are unaffected.
- Scope: no other package variants, version declarations, or recipe logic were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->